### PR TITLE
DSD-148: Fix GitHub Actions Workflow (backend.yml) Output Formatting for Changed Packages

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -45,8 +45,8 @@ jobs:
             echo "packages=" >> $GITHUB_OUTPUT
             exit 0
           fi
-          packages=$(echo "$changed_files" | xargs -n1 dirname | sort | uniq)
-          echo "packages=$packages" >> $GITHUB_OUTPUT
+          packages=$(echo "$changed_files" | xargs -n1 dirname | sort | uniq | tr '\n' ' ')
+          echo "packages=$(echo $packages | tr ' ' ',')" >> $GITHUB_OUTPUT
           echo "Packages to test: $packages"
 
       - name: Test Changed Packages

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -60,7 +60,8 @@ jobs:
           SMTP_TEST_EMAIL: ${{vars.SMTP_TEST_EMAIL}}
           SMTP_FROM: ${{vars.SMTP_FROM}}
         run: |
-          for pkg in ${{ steps.check_changes.outputs.packages }}; do
+          IFS=',' read -ra pkgs <<< "${{ steps.check_changes.outputs.packages }}"
+          for pkg in "${pkgs[@]}"; do
             echo "Running tests in package: $pkg"
             pkg_relative=${pkg#backend/}
             go test -v ./$pkg_relative/...


### PR DESCRIPTION
The GitHub Actions workflow in backend.yml fails due to incorrect formatting when assigning changed package paths to GITHUB_OUTPUT. The issue occurs because the output variable expects a single-line string, but the current script produces a newline-separated list, leading to an Invalid format error.