### PR TITLE
Add script for testing backend locally via container

### DIFF
--- a/backend/Taskfile.yaml
+++ b/backend/Taskfile.yaml
@@ -33,7 +33,7 @@ tasks:
       #   SELECT '{{.POSTGRES_USER}}' AS current_user,
       #      '{{.POSTGRES_PASSWORD}}' AS current_password,
       #      '{{.POSTGRES_DB}}' AS current_db) SELECT * FROM settings;" > /dev/null 2>&1
-      - psql -h postgres -U {{.POSTGRES_USER}} -d {{.POSTGRES_DB}} -c "SELECT 'Hidden'" 
+      - psql -h postgres -U {{.POSTGRES_USER}} -d {{.POSTGRES_DB}} -c "SELECT 'Hidden'"
       - migrate -path {{.MPATH}} -database "{{.PG_URL}}" -verbose up # > /dev/null 2>&1
       - echo "Migrations applied!"
 
@@ -63,3 +63,13 @@ tasks:
     cmds:
       - migrate -path {{.MPATH}} -database "{{.PG_URL}}" -verbose down
       - migrate -path {{.MPATH}} -database "{{.PG_URL}}" -verbose up
+  test:all:
+    desc: "Test all in backend in container"
+    cmds:
+      - chmod +x ./scripts/test-all.sh
+      - ./scripts/test-all.sh
+  test:changed:
+    desc: "Test changed files only in backend in container"
+    cmds:
+      - chmod +x ./scripts/test-changed.sh
+      - ./scripts/test-changed.sh

--- a/backend/scripts/test-all.sh
+++ b/backend/scripts/test-all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+CONTAINER_NAME="rentdaddy-backend"
+
+# Check if container is running
+if ! docker ps | grep -q "$CONTAINER_NAME"; then
+  echo "Error: Container $CONTAINER_NAME is not running!"
+  exit 1
+fi
+
+echo "Running all tests in container: $CONTAINER_NAME..."
+docker exec -it "$CONTAINER_NAME" go test -v ./...

--- a/backend/scripts/test-changed.sh
+++ b/backend/scripts/test-changed.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+CONTAINER_NAME="rentdaddy-backend"
+
+# Check if container is running
+if ! docker ps | grep -q "$CONTAINER_NAME"; then
+  echo "Error: Container $CONTAINER_NAME is not running!"
+  exit 1
+fi
+
+# Get changed test files
+CHANGED_TEST_FILES=$(git diff --name-only origin/main HEAD | grep '_test\.go$' || true)
+
+if [ -z "$CHANGED_TEST_FILES" ]; then
+  echo "No changed test files detected. Running all tests..."
+  docker exec -it "$CONTAINER_NAME" go test -v ./...
+else
+  echo "Running tests for changed files..."
+  for file in $CHANGED_TEST_FILES; do
+    docker exec -it "$CONTAINER_NAME" go test -v "$file"
+  done
+fi


### PR DESCRIPTION
Avoid manual exec into container to perform test for backend via scripts:

- Added: backend/scripts/test-all.sh
- Added: backend/scripts/test-changed.sh
- Modified: backend/Taskfile.yml

You can now run:
``yaml
task test:all
``

or

``yaml
task test:changed
``